### PR TITLE
[Backport] Admin-Order-Create-Set-Save-address-checkbox-true-as-default-#106

### DIFF
--- a/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/address.phtml
+++ b/app/code/Magento/Sales/view/adminhtml/templates/order/create/form/address.phtml
@@ -89,7 +89,8 @@ endif; ?>
         <?= $block->getForm()->toHtml() ?>
 
         <div class="admin__field admin__field-option order-save-in-address-book">
-            <input name="<?= $block->getForm()->getHtmlNamePrefix() ?>[save_in_address_book]" type="checkbox" id="<?= $block->getForm()->getHtmlIdPrefix() ?>save_in_address_book" value="1" checked="checked" class="admin__control-checkbox"/>
+            <input name="<?= $block->getForm()->getHtmlNamePrefix() ?>[save_in_address_book]" type="checkbox" id="<?= $block->getForm()->getHtmlIdPrefix() ?>save_in_address_book" value="1"
+                   <?php if (!$block->getDontSaveInAddressBook()): ?> checked="checked"<?php endif; ?> class="admin__control-checkbox"/>
             <label for="<?= $block->getForm()->getHtmlIdPrefix() ?>save_in_address_book"
                    class="admin__field-label"><?= /* @escapeNotVerified */ __('Save in address book') ?></label>
         </div>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/21932
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When admin creates order for customer
Save Address checkbox is not checked by default
it makes accidental problems when you make order and forget to check it - you need to add all customer address data again in new order

I set this checkbox state AS DEFAULT
### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://github.com/magento/community-features/issues/106: Admin Order Create - Save address as default

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. N/A

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
